### PR TITLE
feat: Add weekendColor prop to highlight weekend columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ npm start
 | arrowColor                 | string | Specifies the relationship arrow fill color.                                                   |
 | arrowIndent                | number | Specifies the relationship arrow right indent. Sets in px                                      |
 | todayColor                 | string | Specifies the current period column fill color.                                                |
+| weekendColor               | string | Specifies the weekend columns fill color.                                                      |
 | TooltipContent             |        | Specifies the Tooltip view for selected taskbar.                                               |
 | TaskListHeader             |        | Specifies the task list Header view                                                            |
 | TaskListTable              |        | Specifies the task list Table view                                                             |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -87,6 +87,7 @@ const App = () => {
         onExpanderClick={handleExpanderClick}
         listCellWidth={isChecked ? "155px" : ""}
         columnWidth={columnWidth}
+        weekendColor={"#97979714"}
       />
       <h3>Gantt With Limited Height</h3>
       <Gantt
@@ -102,6 +103,7 @@ const App = () => {
         listCellWidth={isChecked ? "155px" : ""}
         ganttHeight={300}
         columnWidth={columnWidth}
+        weekendColor={"#97979714"}
       />
     </div>
   );

--- a/src/components/gantt/gantt.tsx
+++ b/src/components/gantt/gantt.tsx
@@ -53,7 +53,8 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
   fontFamily = "Arial, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue",
   fontSize = "14px",
   arrowIndent = 20,
-  todayColor = "rgba(252, 248, 227, 0.5)",
+  todayColor = "rgba(252, 248, 227, 1)",
+  weekendColor = "transparent",
   viewDate,
   TooltipContent = StandardTooltipContent,
   TaskListHeader = TaskListHeaderDefault,
@@ -394,6 +395,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     rowHeight,
     dates: dateSetup.dates,
     todayColor,
+    weekendColor,
     rtl,
   };
   const calendarProps: CalendarProps = {

--- a/src/components/grid/grid-body.tsx
+++ b/src/components/grid/grid-body.tsx
@@ -77,11 +77,11 @@ export const GridBody: React.FC<GridBodyProps> = ({
       />
     );
 
-    if (weekendColor !== "transparent" && dates[i + 1] && [0, 6].includes(dates[i + 1].getDay())) {
+    if (weekendColor !== "transparent" && [0, 6].includes(date.getDay())) {
       weekends.push(
         <rect
-          key={"WeekendColumn" + i}
-          x={tickX + columnWidth}
+          key={"WeekendColumn" + date.getTime()}
+          x={tickX}
           y={0}
           width={columnWidth}
           height={y}

--- a/src/components/grid/grid-body.tsx
+++ b/src/components/grid/grid-body.tsx
@@ -10,6 +10,7 @@ export type GridBodyProps = {
   rowHeight: number;
   columnWidth: number;
   todayColor: string;
+  weekendColor: string;
   rtl: boolean;
 };
 export const GridBody: React.FC<GridBodyProps> = ({
@@ -19,6 +20,7 @@ export const GridBody: React.FC<GridBodyProps> = ({
   svgWidth,
   columnWidth,
   todayColor,
+  weekendColor,
   rtl,
 }) => {
   let y = 0;
@@ -60,6 +62,7 @@ export const GridBody: React.FC<GridBodyProps> = ({
   const now = new Date();
   let tickX = 0;
   const ticks: ReactElement[] = [];
+  const weekends: ReactElement[] = [];
   let today: ReactElement = <rect />;
   for (let i = 0; i < dates.length; i++) {
     const date = dates[i];
@@ -73,6 +76,19 @@ export const GridBody: React.FC<GridBodyProps> = ({
         className={styles.gridTick}
       />
     );
+
+    if (weekendColor !== "transparent" && dates[i + 1] && [0, 6].includes(dates[i + 1].getDay())) {
+      weekends.push(
+        <rect
+          key={"WeekendColumn" + i}
+          x={tickX + columnWidth}
+          y={0}
+          width={columnWidth}
+          height={y}
+          fill={weekendColor}
+        />
+      );
+    }
     if (
       (i + 1 !== dates.length &&
         date.getTime() < now.getTime() &&
@@ -121,6 +137,7 @@ export const GridBody: React.FC<GridBodyProps> = ({
       <g className="rows">{gridRows}</g>
       <g className="rowLines">{rowLines}</g>
       <g className="ticks">{ticks}</g>
+      <g className="weekends">{weekends}</g>
       <g className="today">{today}</g>
     </g>
   );

--- a/src/types/public-types.ts
+++ b/src/types/public-types.ts
@@ -113,6 +113,7 @@ export interface StylingOption {
   arrowColor?: string;
   arrowIndent?: number;
   todayColor?: string;
+  weekendColor?: string;
   TooltipContent?: React.FC<{
     task: Task;
     fontSize: string;


### PR DESCRIPTION
## 🎨 Weekend Color Support Feature

이 PR은 [MaTeMaTuK/gantt-task-react PR #122](https://github.com/MaTeMaTuK/gantt-task-react/pull/122)의 "Add new prop weekendColor to grid" 기능을 한국어 버전에 적용한 것입니다.

### ✨ 주요 기능

#### 🗓️ Weekend Highlighting
- **weekendColor** prop으로 주말 컬럼에 배경색 적용
- 토요일(6)과 일요일(0) 자동 감지
- 투명(`transparent`) 설정으로 주말 하이라이트 비활성화 가능

### 🔧 사용 예제

```typescript
import { Gantt } from 'gantt-task-react-19-korean';

<Gantt 
  tasks={tasks}
  weekendColor="#97979714"  // 반투명 회색으로 주말 강조
/>
```

### 🎯 기능 설명

- **weekendColor**: 주말 컬럼의 배경색을 지정
- **기본값**: `"transparent"` (주말 하이라이트 없음)
- **예제 색상**: `"#97979714"` (반투명 회색)
- **동작**: 각 날짜의 `getDay()` 값이 0(일요일) 또는 6(토요일)일 때 색상 적용

### 📁 변경된 파일들

#### Core Files
- `src/types/public-types.ts`: weekendColor prop을 StylingOption에 추가
- `src/components/grid/grid-body.tsx`: 주말 감지 및 색상 적용 로직
- `src/components/gantt/gantt.tsx`: weekendColor prop 전달

#### Example Files
- `example/src/App.tsx`: weekendColor 사용 예제 추가

#### Documentation
- `README.md`: weekendColor 문서 추가

### 🔄 기타 변경사항
- `todayColor` 기본값을 `rgba(252, 248, 227, 0.5)`에서 `rgba(252, 248, 227, 1)`로 변경 (원본 PR과 동일)

### ✅ 테스트
- [x] 빌드 성공
- [x] 주말 컬럼 하이라이트 동작 확인
- [x] TypeScript 타입 검증

### 🙏 Credit
Original PR by [@AquilesOliveiraDev](https://github.com/AquilesOliveiraDev) - [PR #122](https://github.com/MaTeMaTuK/gantt-task-react/pull/122)

이 기능으로 주말에 특별한 규칙이 적용되는 프로젝트에서 시각적으로 주말을 구분할 수 있게 되었습니다! ��

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 간트 차트에서 주말 컬럼의 색상을 지정할 수 있는 새로운 옵션(`weekendColor`)이 추가되었습니다.

* **Style**
  * 오늘 날짜 컬럼의 기본 색상이 반투명에서 불투명으로 변경되었습니다.

* **Documentation**
  * README에 `weekendColor` 옵션에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->