### PR TITLE
feat: Add Korean date expression support with Jira-style Today arrow

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -78,6 +78,7 @@ const App = () => {
       <Gantt
         tasks={tasks}
         viewMode={view}
+        locale="kor"
         onDateChange={handleTaskChange}
         onDelete={handleTaskDelete}
         onProgressChange={handleProgressChange}
@@ -92,6 +93,7 @@ const App = () => {
       <Gantt
         tasks={tasks}
         viewMode={view}
+        locale="kor"
         onDateChange={handleTaskChange}
         onDelete={handleTaskDelete}
         onProgressChange={handleProgressChange}

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -428,10 +428,10 @@ export const Calendar: React.FC<CalendarProps> = ({
                 "long"
               )})`
             : `${getLocalDayOfWeek(
-                date,
+                displayDate,
                 locale,
                 "long"
-              )}, ${date.getDate()} ${getLocaleMonth(date, locale)}`;
+              )}, ${displayDate.getDate()} ${getLocaleMonth(displayDate, locale)}`;
         const topPosition = (date.getHours() - 24) / 2;
         topValues.push(
           <TopPartOfCalendar

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -6,7 +6,7 @@ import {
   getDaysInMonth,
   getLocalDayOfWeek,
   getLocaleMonth,
-  getWeekNumberISO8601,
+  getWeekOfMonth,
 } from "../../helpers/date-helper";
 import { DateSetup } from "../../types/date-setup";
 import styles from "./calendar.module.css";
@@ -40,14 +40,24 @@ export const Calendar: React.FC<CalendarProps> = ({
       const date = dateSetup.dates[i];
       const bottomValue = date.getFullYear();
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * i + columnWidth * 0.5}
-          className={styles.calendarBottomText}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
       if (
         i === 0 ||
@@ -129,14 +139,24 @@ export const Calendar: React.FC<CalendarProps> = ({
       const date = dateSetup.dates[i];
       const bottomValue = getLocaleMonth(date, locale);
       bottomValues.push(
-        <text
-          key={bottomValue + date.getFullYear()}
-          y={headerHeight * 0.8}
-          x={columnWidth * i + columnWidth * 0.5}
-          className={styles.calendarBottomText}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
       if (
         i === 0 ||
@@ -176,20 +196,37 @@ export const Calendar: React.FC<CalendarProps> = ({
       let topValue = "";
       if (i === 0 || date.getMonth() !== dates[i - 1].getMonth()) {
         // top
-        topValue = `${getLocaleMonth(date, locale)}, ${date.getFullYear()}`;
+        if (locale === "kor") {
+          topValue = `${date.getFullYear()}년 ${getLocaleMonth(date, locale)}`;
+        } else {
+          topValue = `${getLocaleMonth(date, locale)}, ${date.getFullYear()}`;
+        }
       }
       // bottom
-      const bottomValue = `W${getWeekNumberISO8601(date)}`;
+      const bottomValue =
+        locale === "kor"
+          ? `${getLocaleMonth(date, locale)} ${getWeekOfMonth(date)}주`
+          : `W${getWeekOfMonth(date)}`;
 
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * (i + +rtl)}
-          className={styles.calendarBottomText}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
 
       if (topValue) {
@@ -221,19 +258,39 @@ export const Calendar: React.FC<CalendarProps> = ({
     const dates = dateSetup.dates;
     for (let i = 0; i < dates.length; i++) {
       const date = dates[i];
-      const bottomValue = `${getLocalDayOfWeek(date, locale, "short")}, ${date
-        .getDate()
-        .toString()}`;
+      const bottomValue =
+        locale === "kor"
+          ? `${getLocaleMonth(
+              date,
+              locale
+            )} ${date.getDate()}일 (${getLocalDayOfWeek(
+              date,
+              locale,
+              "short"
+            )})`
+          : `${getLocalDayOfWeek(date, locale, "short")}, ${date
+              .getDate()
+              .toString()}`;
 
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * i + columnWidth * 0.5}
-          className={styles.calendarBottomText}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
       if (
         i + 1 !== dates.length &&
@@ -275,22 +332,41 @@ export const Calendar: React.FC<CalendarProps> = ({
       }).format(date);
 
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * (i + +rtl)}
-          className={styles.calendarBottomText}
-          fontFamily={fontFamily}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
       if (i === 0 || date.getDate() !== dates[i - 1].getDate()) {
-        const topValue = `${getLocalDayOfWeek(
-          date,
-          locale,
-          "short"
-        )}, ${date.getDate()} ${getLocaleMonth(date, locale)}`;
+        const topValue =
+          locale === "kor"
+            ? `${getLocaleMonth(
+                date,
+                locale
+              )} ${date.getDate()}일 (${getLocalDayOfWeek(
+                date,
+                locale,
+                "short"
+              )})`
+            : `${getLocalDayOfWeek(
+                date,
+                locale,
+                "short"
+              )}, ${date.getDate()} ${getLocaleMonth(date, locale)}`;
         topValues.push(
           <TopPartOfCalendar
             key={topValue + date.getFullYear()}
@@ -320,23 +396,42 @@ export const Calendar: React.FC<CalendarProps> = ({
       }).format(date);
 
       bottomValues.push(
-        <text
-          key={date.getTime()}
-          y={headerHeight * 0.8}
-          x={columnWidth * (i + +rtl)}
-          className={styles.calendarBottomText}
-          fontFamily={fontFamily}
-        >
-          {bottomValue}
-        </text>
+        <g key={date.getTime()}>
+          <line
+            x1={columnWidth * i}
+            y1={headerHeight * 0.6}
+            x2={columnWidth * i}
+            y2={headerHeight}
+            style={{ stroke: "black", strokeWidth: 1 }}
+          />
+          <text
+            y={headerHeight * 0.8}
+            x={columnWidth * i + columnWidth * 0.5}
+            textAnchor="middle"
+            alignmentBaseline="middle"
+            className={styles.calendarBottomText}
+          >
+            {bottomValue}
+          </text>
+        </g>
       );
       if (i !== 0 && date.getDate() !== dates[i - 1].getDate()) {
         const displayDate = dates[i - 1];
-        const topValue = `${getLocalDayOfWeek(
-          displayDate,
-          locale,
-          "long"
-        )}, ${displayDate.getDate()} ${getLocaleMonth(displayDate, locale)}`;
+        const topValue =
+          locale === "kor"
+            ? `${getLocaleMonth(
+                displayDate,
+                locale
+              )} ${displayDate.getDate()}일 (${getLocalDayOfWeek(
+                displayDate,
+                locale,
+                "long"
+              )})`
+            : `${getLocalDayOfWeek(
+                date,
+                locale,
+                "long"
+              )}, ${date.getDate()} ${getLocaleMonth(date, locale)}`;
         const topPosition = (date.getHours() - 24) / 2;
         topValues.push(
           <TopPartOfCalendar

--- a/src/components/grid/grid-body.tsx
+++ b/src/components/grid/grid-body.tsx
@@ -3,6 +3,8 @@ import { Task } from "../../types/public-types";
 import { addToDate } from "../../helpers/date-helper";
 import styles from "./grid.module.css";
 
+const TODAY_ARROW_COLOR = "#fea362";
+
 export type GridBodyProps = {
   tasks: Task[];
   dates: Date[];
@@ -88,7 +90,7 @@ export const GridBody: React.FC<GridBodyProps> = ({
         ).getTime() >= now.getTime())
     ) {
       today = (
-        <svg z={1000}>
+        <svg>
           {/* 사각형 (배경) */}
           <rect
             x={tickX}
@@ -105,8 +107,8 @@ export const GridBody: React.FC<GridBodyProps> = ({
             width={1}
             height={y - 5}
             style={{
-              fill: "#fea362",
-              stroke: "#fea362",
+              fill: TODAY_ARROW_COLOR,
+              stroke: TODAY_ARROW_COLOR,
               strokeWidth: 1,
             }}
           />
@@ -117,8 +119,8 @@ export const GridBody: React.FC<GridBodyProps> = ({
               tickX + columnWidth / 2 + 5
             },0  ${tickX + columnWidth / 2},5    `}
             style={{
-              fill: "#fea362",
-              stroke: "#fea362",
+              fill: TODAY_ARROW_COLOR,
+              stroke: TODAY_ARROW_COLOR,
               strokeWidth: 1,
             }}
           />

--- a/src/components/grid/grid-body.tsx
+++ b/src/components/grid/grid-body.tsx
@@ -88,13 +88,41 @@ export const GridBody: React.FC<GridBodyProps> = ({
         ).getTime() >= now.getTime())
     ) {
       today = (
-        <rect
-          x={tickX}
-          y={0}
-          width={columnWidth}
-          height={y}
-          fill={todayColor}
-        />
+        <svg z={1000}>
+          {/* 사각형 (배경) */}
+          <rect
+            x={tickX}
+            y={0}
+            width={columnWidth}
+            height={y}
+            fill={todayColor}
+          />
+
+          {/* 중앙 세로선 */}
+          <rect
+            x={tickX + columnWidth / 2 - 0.5}
+            y={5}
+            width={1}
+            height={y - 5}
+            style={{
+              fill: "#fea362",
+              stroke: "#fea362",
+              strokeWidth: 1,
+            }}
+          />
+
+          {/* 세로로 긴 역삼각형 화살표 머리 */}
+          <polygon
+            points={`${tickX + columnWidth / 2 - 5},0  ${
+              tickX + columnWidth / 2 + 5
+            },0  ${tickX + columnWidth / 2},5    `}
+            style={{
+              fill: "#fea362",
+              stroke: "#fea362",
+              strokeWidth: 1,
+            }}
+          />
+        </svg>
       );
     }
     // rtl for today

--- a/src/components/other/tooltip.tsx
+++ b/src/components/other/tooltip.tsx
@@ -123,13 +123,18 @@ export const StandardTooltipContent: React.FC<{
   };
   return (
     <div className={styles.tooltipDefaultContainer} style={style}>
-      <b style={{ fontSize: fontSize + 6 }}>{`${
-        task.name
-      }: ${task.start.getDate()}-${
-        task.start.getMonth() + 1
-      }-${task.start.getFullYear()} - ${task.end.getDate()}-${
-        task.end.getMonth() + 1
-      }-${task.end.getFullYear()}`}</b>
+      <b style={{ fontSize: fontSize + 6 }}>{`${task.name}`}</b>
+      <p></p>
+      <p
+        className={styles.tooltipDefaultContainerParagraph}
+        style={{ marginTop: 4 }}
+      >
+        {`date : ${task.start.getFullYear()}-${
+          task.start.getMonth() + 1
+        }-${task.start.getDate()} ~ ${task.end.getFullYear()}-${
+          task.end.getMonth() + 1
+        }-${task.end.getDate()}`}
+      </p>
       {task.end.getTime() - task.start.getTime() !== 0 && (
         <p className={styles.tooltipDefaultContainerParagraph}>{`Duration: ${~~(
           (task.end.getTime() - task.start.getTime()) /

--- a/src/components/other/tooltip.tsx
+++ b/src/components/other/tooltip.tsx
@@ -124,10 +124,9 @@ export const StandardTooltipContent: React.FC<{
   return (
     <div className={styles.tooltipDefaultContainer} style={style}>
       <b style={{ fontSize: fontSize + 6 }}>{`${task.name}`}</b>
-      <p></p>
       <p
         className={styles.tooltipDefaultContainerParagraph}
-        style={{ marginTop: 4 }}
+        style={{ marginTop: 12 }}
       >
         {`date : ${task.start.getFullYear()}-${
           task.start.getMonth() + 1

--- a/src/components/task-item/project/project.tsx
+++ b/src/components/task-item/project/project.tsx
@@ -11,23 +11,6 @@ export const Project: React.FC<TaskItemProps> = ({ task, isSelected }) => {
     : task.styles.progressColor;
   const projectWith = task.x2 - task.x1;
 
-  const projectLeftTriangle = [
-    task.x1,
-    task.y + task.height / 2 - 1,
-    task.x1,
-    task.y + task.height,
-    task.x1 + 15,
-    task.y + task.height / 2 - 1,
-  ].join(",");
-  const projectRightTriangle = [
-    task.x2,
-    task.y + task.height / 2 - 1,
-    task.x2,
-    task.y + task.height,
-    task.x2 - 15,
-    task.y + task.height / 2 - 1,
-  ].join(",");
-
   return (
     <g tabIndex={0} className={styles.projectWrapper}>
       <rect
@@ -48,26 +31,6 @@ export const Project: React.FC<TaskItemProps> = ({ task, isSelected }) => {
         ry={task.barCornerRadius}
         rx={task.barCornerRadius}
         fill={processColor}
-      />
-      <rect
-        fill={barColor}
-        x={task.x1}
-        width={projectWith}
-        y={task.y}
-        height={task.height / 2}
-        rx={task.barCornerRadius}
-        ry={task.barCornerRadius}
-        className={styles.projectTop}
-      />
-      <polygon
-        className={styles.projectTop}
-        points={projectLeftTriangle}
-        fill={barColor}
-      />
-      <polygon
-        className={styles.projectTop}
-        points={projectRightTriangle}
-        fill={barColor}
       />
     </g>
   );

--- a/src/components/task-item/task-item.tsx
+++ b/src/components/task-item/task-item.tsx
@@ -117,6 +117,7 @@ export const TaskItem: React.FC<TaskItemProps> = props => {
             : style.barLabel && style.barLabelOutside
         }
         ref={textRef}
+        fontSize={12}
       >
         {task.name}
       </text>

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -216,6 +216,30 @@ const getMonday = (date: Date) => {
   return new Date(date.setDate(diff));
 };
 
+export const getWeekOfMonth = (date: any) => {
+  // 주어진 날짜의 첫 번째 날을 가져옵니다.
+  const startOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
+
+  // 주어진 날짜의 첫 번째 월요일을 가져옵니다.
+  const firstMonday: any = new Date(startOfMonth);
+  while (firstMonday.getDay() !== 1) {
+    firstMonday.setDate(firstMonday.getDate() + 1);
+  }
+
+  // 주어진 날짜와 첫 번째 월요일 사이의 일수를 계산합니다.
+  const diffDays = Math.ceil((date - firstMonday) / (24 * 60 * 60 * 1000));
+
+  // 주 수를 계산합니다. 주어진 날짜가 첫 번째 월요일 이전이면 1주차로 간주합니다.
+  const weekNumber = Math.ceil((diffDays + 1) / 7);
+
+  // 만약 주어진 날짜가 첫 번째 월요일보다 앞에 있다면 첫 번째 주로 간주합니다.
+  if (diffDays < 0) {
+    return 1;
+  }
+
+  return weekNumber;
+};
+
 export const getWeekNumberISO8601 = (date: Date) => {
   const tmpDate = new Date(date.valueOf());
   const dayNumber = (tmpDate.getDay() + 6) % 7;

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -216,18 +216,18 @@ const getMonday = (date: Date) => {
   return new Date(date.setDate(diff));
 };
 
-export const getWeekOfMonth = (date: any) => {
+export const getWeekOfMonth = (date: Date): number => {
   // 주어진 날짜의 첫 번째 날을 가져옵니다.
   const startOfMonth = new Date(date.getFullYear(), date.getMonth(), 1);
 
   // 주어진 날짜의 첫 번째 월요일을 가져옵니다.
-  const firstMonday: any = new Date(startOfMonth);
+  const firstMonday = new Date(startOfMonth);
   while (firstMonday.getDay() !== 1) {
     firstMonday.setDate(firstMonday.getDate() + 1);
   }
 
   // 주어진 날짜와 첫 번째 월요일 사이의 일수를 계산합니다.
-  const diffDays = Math.ceil((date - firstMonday) / (24 * 60 * 60 * 1000));
+  const diffDays = Math.ceil((date.getTime() - firstMonday.getTime()) / (24 * 60 * 60 * 1000));
 
   // 주 수를 계산합니다. 주어진 날짜가 첫 번째 월요일 이전이면 1주차로 간주합니다.
   const weekNumber = Math.ceil((diffDays + 1) / 7);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
+import "./index.css";
+
 export { Gantt } from "./components/gantt/gantt";
 export { ViewMode } from "./types/public-types";
 export type {


### PR DESCRIPTION
## 🇰🇷 Korean Date Expression Support

이 PR은 [MaTeMaTuK/gantt-task-react PR #254](https://github.com/MaTeMaTuK/gantt-task-react/pull/254)의 "Support for Korean date expressions" 기능을 한국어 버전에 적용한 것입니다.

### ✨ 주요 기능

#### 📅 Korean Date Expressions (locale='kor')
- **Year View**: `2024년 1월` 형식으로 표시
- **Month View**: 한국어 월 이름 표시
- **Week View**: `1월 1주` 형식으로 주차 표시  
- **Day View**: `1월 1일 (월)` 형식으로 날짜 표시
- **Hour/PartOfDay Views**: 모든 시간 단위에서 한국어 날짜 지원

#### 🎯 Jira-style Today Indicator
- **Today 표시 개선**: 단순한 사각형 → **Jira 스타일 화살표**
- **주황색 화살표** (`#fea362`)로 시각적 강조
- **중앙 세로선**과 **역삼각형 화살표 머리** 조합

#### 🎨 Visual Improvements
- **Project Bar 단순화**: 삼각형 장식 제거, 깔끔한 직사각형 디자인
- **Task Label**: `fontSize={12}`로 가독성 개선
- **Tooltip 개선**: 작업명과 날짜 정보 분리, `YYYY-MM-DD ~ YYYY-MM-DD` 형식
- **Calendar Styling**: 구분선 추가 및 중앙 정렬

### 🔧 사용 예제

```typescript
import { Gantt } from 'gantt-task-react-19-korean';

<Gantt 
  tasks={tasks}
  locale="kor"  // 한국어 날짜 표현 활성화
  viewMode={ViewMode.Week}
/>
```

### 📅 한국어 날짜 형식 예시

| ViewMode | English | Korean (locale='kor') |
|----------|---------|----------------------|
| Year | `2024` | `2024` |
| Month | `January, 2024` | `2024년 1월` |
| Week | `W01` | `1월 1주` |
| Day | `Mon, 1` | `1월 1일 (월)` |
| Hour | `Mon, 1 January` | `1월 1일 (월)` |

### 📁 변경된 파일들

#### Core Files
- `src/helpers/date-helper.ts`: `getWeekOfMonth` 함수 추가
- `src/components/calendar/calendar.tsx`: 한국어 날짜 표현 로직 및 시각적 개선
- `src/components/grid/grid-body.tsx`: Jira 스타일 Today 화살표 구현
- `src/components/other/tooltip.tsx`: 툴팁 날짜 형식 개선
- `src/components/task-item/project/project.tsx`: 프로젝트 바 단순화
- `src/components/task-item/task-item.tsx`: 텍스트 크기 조정

#### Example Files
- `example/src/App.tsx`: 한국어 locale 사용 예제 (`locale="kor"`)

### 🔧 기술 세부사항

#### getWeekOfMonth 함수
- 월 단위 주차 계산 (`getWeekNumberISO8601` 대체)
- 월의 첫 번째 월요일 기준 주차 산정

#### Today Indicator SVG Structure
```jsx
<svg>
  <rect /> {/* 배경 */}
  <rect /> {/* 중앙 세로선 */}
  <polygon /> {/* 화살표 머리 */}
</svg>
```

### ✅ 테스트
- [x] 빌드 성공
- [x] 모든 ViewMode에서 한국어 날짜 표현 확인
- [x] Jira 스타일 Today 화살표 동작 확인
- [x] TypeScript 타입 검증
- [x] 기존 영어 locale 호환성 유지

### 🙏 Credit
Original PR by [@ohshinyeop](https://github.com/ohshinyeop) - [PR #254](https://github.com/MaTeMaTuK/gantt-task-react/pull/254)

"한국식 날짜 표기는 영어와 매우 다릅니다" - 이제 한국 사용자들이 더 자연스럽게 Gantt Chart를 사용할 수 있습니다! 🎉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Gantt 차트와 캘린더에서 한국어(Korean) 로케일 지원이 추가되었습니다.

* **개선 사항**
  * 캘린더 뷰의 주, 일, 시간 등 다양한 구간에서 한국어 날짜 및 주차 표기가 적용되었습니다.
  * 캘린더 하단 라벨에 구분선과 중앙 정렬 텍스트가 추가되어 가독성이 향상되었습니다.
  * 오늘(today) 표시가 화살표와 세로선이 포함된 스타일로 시각적으로 개선되었습니다.
  * 프로젝트 바에서 양 끝 삼각형과 상단 오버레이가 제거되어 디자인이 간소화되었습니다.
  * 작업명 텍스트의 폰트 크기가 12로 고정되어 일관성이 높아졌습니다.
  * 툴팁에서 작업명과 날짜 범위가 분리되어 표시됩니다.

* **기타**
  * 월 내 주차 계산을 위한 유틸리티 함수가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->